### PR TITLE
chore: release v0.2.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.20](https://github.com/andreacfromtheapp/freesound-credits/compare/v0.2.19...v0.2.20)
+
+### 🐛 Bug Fixes
+
+- Restoring README.md for crates.io ([#74](https://github.com/andreacfromtheapp/freesound-credits/pull/74)) - ([d1fc402](https://github.com/andreacfromtheapp/freesound-credits/commit/d1fc4029cb45efb19f58b4df7acdca6a3e9ff2f6))
+
 ## [0.2.19](https://github.com/andreacfromtheapp/freesound-credits/compare/v0.2.18...v0.2.19)
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "freesound-credits"
-version = "0.2.19"
+version = "0.2.20"
 dependencies = [
  "clap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freesound-credits"
-version = "0.2.19"
+version = "0.2.20"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
## 🤖 New release
* `freesound-credits`: 0.2.19 -> 0.2.20 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.20](https://github.com/andreacfromtheapp/freesound-credits/compare/v0.2.19...v0.2.20)

### 🐛 Bug Fixes

- Restoring README.md for crates.io ([#74](https://github.com/andreacfromtheapp/freesound-credits/pull/74)) - ([d1fc402](https://github.com/andreacfromtheapp/freesound-credits/commit/d1fc4029cb45efb19f58b4df7acdca6a3e9ff2f6))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).