### PR TITLE
chore: release v0.2.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.24](https://github.com/andreacfromtheapp/freesound-credits/compare/v0.2.23...v0.2.24)
+
+### ⚙️ Miscellaneous Tasks
+
+- Minor updates (#87) - ([6449396](https://github.com/andreacfromtheapp/freesound-credits/commit/64493962e7c89c482303eaa96e14df07f09ff425))
+
 ## [0.2.22](https://github.com/andreacfromtheapp/freesound-credits/compare/v0.2.21...v0.2.22)
 
 ### ⚙️ Miscellaneous Tasks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "freesound-credits"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "clap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freesound-credits"
-version = "0.2.23"
+version = "0.2.24"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## 🤖 New release
* `freesound-credits`: 0.2.23 -> 0.2.24 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.24](https://github.com/andreacfromtheapp/freesound-credits/compare/v0.2.23...v0.2.24)

### ⚙️ Miscellaneous Tasks

- Minor updates (#87) - ([6449396](https://github.com/andreacfromtheapp/freesound-credits/commit/64493962e7c89c482303eaa96e14df07f09ff425))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).