### PR TITLE
chore: release v0.2.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.25](https://github.com/andreacfromtheapp/freesound-credits/compare/v0.2.24...v0.2.25)
+
+### ⚙️ Miscellaneous Tasks
+
+- Add workflows and pre-hooks and vale (#90) - ([c806e54](https://github.com/andreacfromtheapp/freesound-credits/commit/c806e54dc42fe4beed4bcc33342463a574c693fc))
+
 ## [0.2.24](https://github.com/andreacfromtheapp/freesound-credits/compare/v0.2.23...v0.2.24)
 
 ### ⚙️ Miscellaneous Tasks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "freesound-credits"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "clap",
 ]
@@ -127,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -142,9 +142,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.90"
+version = "2.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "987bc0be1cdea8b10216bd06e2ca407d40b9543468fafd3ddfb02f36e77f71f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freesound-credits"
-version = "0.2.24"
+version = "0.2.25"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## 🤖 New release
* `freesound-credits`: 0.2.24 -> 0.2.25 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.25](https://github.com/andreacfromtheapp/freesound-credits/compare/v0.2.24...v0.2.25)

### ⚙️ Miscellaneous Tasks

- Add workflows and pre-hooks and vale (#90) - ([c806e54](https://github.com/andreacfromtheapp/freesound-credits/commit/c806e54dc42fe4beed4bcc33342463a574c693fc))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).