### PR TITLE
chore: release v0.2.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.27](https://github.com/andreacfromtheapp/freesound-credits/compare/v0.2.26...v0.2.27)
+
+### ⚙️ Miscellaneous Tasks
+
+- Del spellcheck + md fixes + minor changes (#104) - ([0617c36](https://github.com/andreacfromtheapp/freesound-credits/commit/0617c3689a4ddd4a8e54129359a4ede5d3069c11))
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "freesound-credits"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "clap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freesound-credits"
-version = "0.2.26"
+version = "0.2.27"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION



## 🤖 New release

* `freesound-credits`: 0.2.26 -> 0.2.27 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).