### PR TITLE
chore: release v0.2.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.31](https://github.com/andreacfromtheapp/freesound-credits/compare/v0.2.30...v0.2.31)
+
+### 🐛 Bug Fixes
+
+- Del custom runners but top level ([#120](https://github.com/andreacfromtheapp/freesound-credits/pull/120)) - ([a0fe93f](https://github.com/andreacfromtheapp/freesound-credits/commit/a0fe93f526a77861228491113709cb5a54313b1e))
+
 ## [0.2.30](https://github.com/andreacfromtheapp/freesound-credits/compare/v0.2.29...v0.2.30)
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "freesound-credits"
-version = "0.2.30"
+version = "0.2.31"
 dependencies = [
  "clap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freesound-credits"
-version = "0.2.30"
+version = "0.2.31"
 edition = "2024"
 resolver = "3"
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `freesound-credits`: 0.2.30 -> 0.2.31 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).