### PR TITLE
chore: release v0.2.33

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "freesound-credits"
-version = "0.2.32"
+version = "0.2.33"
 dependencies = [
  "clap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freesound-credits"
-version = "0.2.32"
+version = "0.2.33"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION



## 🤖 New release

* `freesound-credits`: 0.2.32 -> 0.2.33 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).